### PR TITLE
脆弱性修正PRを作成しなくてもよいケースを考慮

### DIFF
--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -115,7 +115,7 @@ runs:
         git fetch origin $BRANCH_NAME
         pr_branch_exist=$(echo $?)
         # 修正対象行があるかチェック
-        cat ${{ inputs.dockerfile-path }} | grep "package-cache-v"
+        grep "package-cache-v" ${{ inputs.dockerfile-path }}
         version_up_line_exist=$(echo $?)
         if [ $pr_branch_exist -ne 0 ] && [ $version_up_line_exist -eq 0 ]; then
           echo "SHOULD_CREATE_PR=true" >> $GITHUB_ENV

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -113,7 +113,11 @@ runs:
 
         # PR作成ブランチの存在チェック
         git fetch origin $BRANCH_NAME
-        if [ $? -ne 0 ]; then
+        pr_branch_exist=$(echo $?)
+        # 修正対象行があるかチェック
+        cat ${{ inputs.dockerfile-path }} | grep "package-cache-v"
+        version_up_line_exist=$(echo $?)
+        if [ $pr_branch_exist -ne 0 ] && [ $version_up_line_exist -eq 0 ]; then
           echo "SHOULD_CREATE_PR=true" >> $GITHUB_ENV
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           # push時のデフォルトブランチ情報を取得しておく

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -113,11 +113,10 @@ runs:
 
         # PR作成ブランチの存在チェック
         git fetch origin $BRANCH_NAME
-        pr_branch_exist=$(echo $?)
+        pr_branch_exist="$?"
         # 修正対象行があるかチェック
-        grep "package-cache-v" ${{ inputs.dockerfile-path }}
-        version_up_line_exist=$(echo $?)
-        if [ $pr_branch_exist -ne 0 ] && [ $version_up_line_exist -eq 0 ]; then
+        version_up_line=`grep "package-cache-v" ${{ inputs.dockerfile-path }}`
+        if [ $pr_branch_exist -ne 0 ] && [ -n "$version_up_line" ]; then
           echo "SHOULD_CREATE_PR=true" >> $GITHUB_ENV
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           # push時のデフォルトブランチ情報を取得しておく


### PR DESCRIPTION
キャッシュ破棄用の`package-cache-v`の記述がない場合に脆弱性修正PRを出す必要はないが出そうとしてエラーになっている。そのためエラーにならないように修正
