### PR TITLE
他の脆弱性検知IssueがCloseされるバグ修正

### DIFF
--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -68,7 +68,7 @@ runs:
         cat trivy-results.txt | tee -a $GITHUB_STEP_SUMMARY
 
     - name: Set image name
-      if: github.event_name == 'schedule' && env.FOUND_VULNERABILITY == 'true'
+      if: github.event_name == 'schedule'
       shell: bash
       run: |
         if [ -n "${{ inputs.image-name }}" ]; then


### PR DESCRIPTION
他の脆弱性検知IssueがCloseされるバグ修正
脆弱性が見つからなかった場合、IMAGE_NAMEがセットされないので関係ないissueがcloseされるケースがあるため。
修正内容としては脆弱性が見つからなかった場合でも`IMAGE_NAME`変数がセットされるように修正。


社内リンクが含まれているのでmerge後説明文を修正します